### PR TITLE
Add an endpoint to get a character of a random ancestry

### DIFF
--- a/src/sotdl-api/sotdl-app.py
+++ b/src/sotdl-api/sotdl-app.py
@@ -1,4 +1,7 @@
-from flask import Flask, jsonify, render_template
+"""HTTP API endpoint"""
+import random
+
+from flask import Flask, jsonify, redirect, render_template, url_for
 from ancestry import (
     Changeling,
     Clockwork,
@@ -17,6 +20,21 @@ app.config['JSON_AS_ASCII'] = False
 @app.route('/')
 def hello_world():
     return render_template('index.html')
+
+
+@app.route('/random/')
+def create_random():
+    """Get a random character"""
+    return redirect(url_for('create_{}'.format(random.choice((
+        'changeling',
+        'clockwork',
+        'dwarf',
+        'faun',
+        'goblin',
+        'halfling',
+        'human',
+        'orc',
+    )))))
 
 
 @app.route('/changeling/', defaults={'name': None})

--- a/src/sotdl-api/templates/index.html
+++ b/src/sotdl-api/templates/index.html
@@ -24,5 +24,11 @@
         <li>GET <a href="{{ url_for('create_orc') }}">/orc</a></li>
         <li>GET <a href="{{ url_for('create_orc') }}">/orc/{name}</a></li>
     </ul>
+    <p>
+        Or, if you're feeling particularly adventurous, use the random endpoint!
+    </p>
+    <ul>
+        <li>GET <a href="{{ url_for('create_random') }}">/random/</a></li>
+    </ul>
 </body>
 </html>


### PR DESCRIPTION
This introduces an endpoint that will redirect users to a random ancestry.  I dropped the name parameter since I feel that the name should generally follow the ancestry.

```
$ http get localhost:5000/random/
HTTP/1.0 302 FOUND
Content-Length: 219
Content-Type: text/html; charset=utf-8
Date: Mon, 26 Mar 2018 23:26:04 GMT
Location: http://localhost:5000/faun/
Server: Werkzeug/0.14.1 Python/3.6.3

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>Redirecting...</title>
<h1>Redirecting...</h1>
<p>You should be redirected automatically to target URL: <a href="/faun/">/faun/</a>.  If not click the link.
```